### PR TITLE
fix: fail Fn::Eval, Fn::IfEval if opts.doEval is falsy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    commit-message: # force conventional commits standard
+      prefix: fix
+      prefix-development: chore
+      include: scope

--- a/index.js
+++ b/index.js
@@ -236,7 +236,10 @@ async function recurse({ base, scope, cft, ...opts }) {
         }
       );
     }
-    if (cft['Fn::Eval'] && opts.doEval) {
+    if (cft['Fn::Eval']) {
+      if (!opts.doEval) {
+        return Promise.reject(new Error('Fn::Eval is not allowed doEval is falsy'));
+      }
       return recurse({ base, scope, cft: cft['Fn::Eval'], ...opts }).then(function (json) {
         // **WARNING** you have now enabled god mode
         // eslint-disable-next-line no-unused-vars, prefer-const
@@ -391,7 +394,10 @@ async function recurse({ base, scope, cft, ...opts }) {
       return isString ? seq.map((i) => String.fromCharCode(i)) : seq;
     }
 
-    if (cft['Fn::IfEval'] && opts.doEval) {
+    if (cft['Fn::IfEval']) {
+      if (!opts.doEval) {
+        return Promise.reject(new Error('Fn::IfEval is not allowed doEval is falsy'));
+      }
       return recurse({ base, scope, cft: cft['Fn::IfEval'], ...opts }).then(function (json) {
         // eslint-disable-next-line prefer-const
         let { truthy, falsy, evalCond, inject, doLog } = json;

--- a/t/include.js
+++ b/t/include.js
@@ -30,6 +30,7 @@ const tests = [
   'omit.json',
   'omitEmpty.json',
   'ifeval.js',
+  'eval.js',
   'amzn-intrinsic.yml',
   'joinNow.yml',
   'applyTags.yml',

--- a/t/tests/eval.js
+++ b/t/tests/eval.js
@@ -1,0 +1,24 @@
+module.exports = {
+  ifEval: [
+    {
+      name: 'truthy',
+      doEval: true,
+      template: {
+        'Fn::Eval': {
+          state: [1, 2, 3],
+          script: `state.map((v) => 2 * v);`,
+        },
+      },
+      output: [2, 4, 6],
+    },
+    {
+      name: 'should fail',
+      doEval: false,
+      // test should fail as doEval is disabled
+      catch: (err) => err instanceof Error,
+      template: {
+        'Fn::Eval': {},
+      },
+    },
+  ],
+};

--- a/t/tests/ifeval.js
+++ b/t/tests/ifeval.js
@@ -25,6 +25,32 @@ module.exports = {
       },
     },
     {
+      name: 'should fail',
+      doEval: false,
+      // test should fail as doEval is disabled
+      catch: (err) => err instanceof Error,
+      template: {
+        'Fn::IfEval': {
+          inject: {
+            lastName: 'bear',
+          },
+          evalCond: "'$lastName' === 'bear'",
+          truthy: {
+            Name: 'Yogi',
+            LastName: 'Bear',
+          },
+          falsy: {
+            Name: 'Fred',
+            LastName: 'Flint',
+          },
+        },
+      },
+      output: {
+        Name: 'Yogi',
+        LastName: 'Bear',
+      },
+    },
+    {
       name: 'falsy',
       doEval: true,
       template: {


### PR DESCRIPTION
- force promise failure on Fn::Eval and Fn::IfEval if doLog is falsy
- force dependabot for conventional commit chore standard